### PR TITLE
Easily adjust top & bottom offsets of the indicator view

### DIFF
--- a/Sources/SPIndicator/Models/SPIndicatorLayout.swift
+++ b/Sources/SPIndicator/Models/SPIndicatorLayout.swift
@@ -37,19 +37,13 @@ open class SPIndicatorLayout {
     open var margins: UIEdgeInsets
      
     /**
-     SPIndicator: Alert top offset
+     SPIndicator: Alert offset
      */
-    open var topOffset: CGFloat
+    open var offset: CGFloat
     
-    /**
-     SPIndicator: Alert bottom offset
-     */
-    open var bottomOffset: CGFloat
-    
-    public init(iconSize: CGSize, margins: UIEdgeInsets, topOffset: CGFloat = 0, bottomOffset: CGFloat = 0) {
+    public init(iconSize: CGSize, margins: UIEdgeInsets, offset: CGFloat = 0) {
         self.iconSize = iconSize
         self.margins = margins
-        self.topOffset = topOffset
-        self.bottomOffset = bottomOffset
+        self.offset = offset
     }
 }

--- a/Sources/SPIndicator/Models/SPIndicatorLayout.swift
+++ b/Sources/SPIndicator/Models/SPIndicatorLayout.swift
@@ -35,15 +35,9 @@ open class SPIndicatorLayout {
      SPIndicator: Alert margings for each side.
      */
     open var margins: UIEdgeInsets
-     
-    /**
-     SPIndicator: Alert offset
-     */
-    open var offset: CGFloat
     
-    public init(iconSize: CGSize, margins: UIEdgeInsets, offset: CGFloat = 0) {
+    public init(iconSize: CGSize, margins: UIEdgeInsets) {
         self.iconSize = iconSize
         self.margins = margins
-        self.offset = offset
     }
 }

--- a/Sources/SPIndicator/Models/SPIndicatorLayout.swift
+++ b/Sources/SPIndicator/Models/SPIndicatorLayout.swift
@@ -35,9 +35,21 @@ open class SPIndicatorLayout {
      SPIndicator: Alert margings for each side.
      */
     open var margins: UIEdgeInsets
+     
+    /**
+     SPIndicator: Alert top offset
+     */
+    open var topOffset: CGFloat
     
-    public init(iconSize: CGSize, margins: UIEdgeInsets) {
+    /**
+     SPIndicator: Alert bottom offset
+     */
+    open var bottomOffset: CGFloat
+    
+    public init(iconSize: CGSize, margins: UIEdgeInsets, topOffset: CGFloat = 0, bottomOffset: CGFloat = 0) {
         self.iconSize = iconSize
         self.margins = margins
+        self.topOffset = topOffset
+        self.bottomOffset = bottomOffset
     }
 }

--- a/Sources/SPIndicator/SPIndicatorView.swift
+++ b/Sources/SPIndicator/SPIndicatorView.swift
@@ -346,13 +346,13 @@ open class SPIndicatorView: UIView {
         case .top:
             var topSafeAreaInsets = window.safeAreaInsets.top
             if topSafeAreaInsets < 20 { topSafeAreaInsets = 20 }
-            let position = topSafeAreaInsets - 3 + layout.topOffset
+            let position = topSafeAreaInsets - 3 + layout.offset
             return CGAffineTransform.identity.translatedBy(x: 0, y: position)
         case .bottom:
             let height = window.frame.height
             var bottomSafeAreaInsets = window.safeAreaInsets.top
             if bottomSafeAreaInsets < 20 { bottomSafeAreaInsets = 20 }
-            let position = height - bottomSafeAreaInsets - 3 - frame.height - layout.bottomOffset
+            let position = height - bottomSafeAreaInsets - 3 - frame.height - layout.offset
             return CGAffineTransform.identity.translatedBy(x: 0, y: position)
         case .center:
             return CGAffineTransform.identity.translatedBy(x: 0, y: window.frame.height / 2 - frame.height / 2)

--- a/Sources/SPIndicator/SPIndicatorView.swift
+++ b/Sources/SPIndicator/SPIndicatorView.swift
@@ -346,13 +346,13 @@ open class SPIndicatorView: UIView {
         case .top:
             var topSafeAreaInsets = window.safeAreaInsets.top
             if topSafeAreaInsets < 20 { topSafeAreaInsets = 20 }
-            let position = topSafeAreaInsets - 3
+            let position = topSafeAreaInsets - 3 + layout.topOffset
             return CGAffineTransform.identity.translatedBy(x: 0, y: position)
         case .bottom:
             let height = window.frame.height
             var bottomSafeAreaInsets = window.safeAreaInsets.top
             if bottomSafeAreaInsets < 20 { bottomSafeAreaInsets = 20 }
-            let position = height - bottomSafeAreaInsets - 3 - frame.height
+            let position = height - bottomSafeAreaInsets - 3 - frame.height - layout.bottomOffset
             return CGAffineTransform.identity.translatedBy(x: 0, y: position)
         case .center:
             return CGAffineTransform.identity.translatedBy(x: 0, y: window.frame.height / 2 - frame.height / 2)

--- a/Sources/SPIndicator/SPIndicatorView.swift
+++ b/Sources/SPIndicator/SPIndicatorView.swift
@@ -346,13 +346,13 @@ open class SPIndicatorView: UIView {
         case .top:
             var topSafeAreaInsets = window.safeAreaInsets.top
             if topSafeAreaInsets < 20 { topSafeAreaInsets = 20 }
-            let position = topSafeAreaInsets - 3 + layout.offset
+            let position = topSafeAreaInsets - 3 + offset
             return CGAffineTransform.identity.translatedBy(x: 0, y: position)
         case .bottom:
             let height = window.frame.height
             var bottomSafeAreaInsets = window.safeAreaInsets.top
             if bottomSafeAreaInsets < 20 { bottomSafeAreaInsets = 20 }
-            let position = height - bottomSafeAreaInsets - 3 - frame.height - layout.offset
+            let position = height - bottomSafeAreaInsets - 3 - frame.height - offset
             return CGAffineTransform.identity.translatedBy(x: 0, y: position)
         case .center:
             return CGAffineTransform.identity.translatedBy(x: 0, y: window.frame.height / 2 - frame.height / 2)
@@ -362,6 +362,11 @@ open class SPIndicatorView: UIView {
     // MARK: - Layout
     
     open var layout: SPIndicatorLayout = .init()
+ 
+    /**
+     SPIndicator: Alert offset
+     */
+    open var offset: CGFloat = 0
     
     private var areaHeight: CGFloat = 50
     private var minimumAreaWidth: CGFloat = 196


### PR DESCRIPTION
Hey 👋

Thanks for this amazing library. 🔥

## Goal

The goal is to easily change the top and bottom offset. From my point of view, on iPhones <= 8, the indicator is too close to the status bar so therefore I implemented an easy way to adjust the offset of the indicator.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Testing in `iOS`, `tvOS`
- [x] Installed correct via Swift Package Manager and Cocoapods
